### PR TITLE
Fix loading gif not showing on image search after asciify applied

### DIFF
--- a/artscii/src/components/main/Main.js
+++ b/artscii/src/components/main/Main.js
@@ -20,6 +20,7 @@ function Main() {
         setSearchParam('')
     }
     const handleSubmit = (e) => {
+        setDisplayMode('image');
         updateTitle(searchParam)
         setApiImage(searchParam);
         setLoading(true);


### PR DESCRIPTION
Sets the display mode to 'image' within handleSubmit so that the loading gif is displayed on subsequent searches after asciifying.